### PR TITLE
fix:unchecked runtime error with no id. error handling of tab closed …

### DIFF
--- a/shorten-aws-icon-names/background.js
+++ b/shorten-aws-icon-names/background.js
@@ -1,17 +1,24 @@
 init = (tab) => {
+  if (!tab) {
+    console.log('Tab not found');
+    return;
+  }
+
   // Check if the tab URL matches the AWS Console pattern
   if (/^https?:\/\/([a-z0-9-]+\.)*console\.aws\.amazon\.com\//.test(tab.url)) {
-    chrome.scripting.executeScript({
-      target: { tabId: tab.id, allFrames: true },
-      files: ['content_script.js'],
-    });
+    chrome.scripting
+      .executeScript({
+        target: { tabId: tab.id, allFrames: true },
+        files: ['content_script.js'],
+      })
+      .catch((error) => {
+        console.log(`Error executing script: ${error}`);
+      });
   }
 };
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
-  if (changeInfo.status === 'complete') {
-    chrome.tabs.get(tabId, (tab) => {
-      init(tab);
-    });
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'complete' && tab.status === 'complete') {
+    init(tab);
   }
 });


### PR DESCRIPTION
…before the code run


> i see 2 errors
> 
> Unchecked runtime.lastError: No tab with id: 995512188.
> 
> Error handling response: TypeError: Cannot read properties of undefined (reading 'url') at init (chrome-extension://clhfnpldgcplknefcglcoogolilbeedk/background.js:3:73) at chrome-extension://clhfnpldgcplknefcglcoogolilbeedk/background.js:14:7
> ChatGPT
> The first error you are encountering, "Unchecked runtime.lastError: No tab with id: 995512188," typically arises when you're trying to interact with a tab (in this case, to inject a script) that no longer exists. This can occur if the tab was closed or navigated to a different page between the time you got its ID and the time you tried to interact with it. It can also occur if your extension's background page gets unloaded, causing the tab's ID to change.
> 
> To solve this, you could use the tab.status to check if the tab is completely loaded before calling your init function. Also, you should include a check for the existence of the tab before calling the init function to avoid trying to interact with a tab that may no longer exist.
> 
> The second error, "TypeError: Cannot read properties of undefined (reading 'url') at init," is because the tab parameter passed into the init function is undefined. This could be due to the fact that the tab was closed before your code could run.
